### PR TITLE
[PKG-12772] 0.22.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
     - conftest.py
     - beartype_test
   commands:
+	# test skipped because of https://github.com/beartype/beartype/issues/620
     - pytest beartype_test --ignore="beartype_test/a00_unit/a00_core/test_a90_typing.py"
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,26 +13,27 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - hatchling >=1.14.0
     - pip
   run:
-    - python >={{ python_min }}
+    - python
 
 test:
   requires:
     - pytest
-    - python {{ python_min }}
+    - python
+    - pip
   source_files:
     - conftest.py
     - beartype_test
   commands:
     - pytest beartype_test
+    - pip check
 
 about:
   home: https://github.com/beartype/beartype

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - conftest.py
     - beartype_test
   commands:
-    - pytest beartype_test
+    - pytest beartype_test --ignore="beartype_test/a00_unit/a00_core/test_a90_typing.py"
     - pip check
 
 about:


### PR DESCRIPTION
beartype 0.22.9

**Destination channel:** defaults

### Links

- [PKG-12772](https://anaconda.atlassian.net/browse/PKG-12722)
- [Upstream repository](https://github.com/beartype/beartype)

### Explanation of changes:

- Minor revisions from conda-forge
- Skipping test_a90_typing.py in tests due to picking up deprecated `Pattern` and  `ContextManager` as being incorrectly publicized by python's typing module.
